### PR TITLE
Add PTLf.o and -lstdc++ flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+include/
+lib/
+obj/
+program

--- a/fortran/testing/makefile
+++ b/fortran/testing/makefile
@@ -9,7 +9,7 @@ run: main
 	./program
 
 main:
-	${fc} -I${basedir}/include main.F90 -o program -L${basedir}/lib -lPTL
+	${fc} -I${basedir}/include ${basedir}/obj/PTLf.o main.F90 -o program -L${basedir}/lib -lPTL -lstdc++
 
 clean:
 	rm -f program

--- a/makefile
+++ b/makefile
@@ -52,7 +52,7 @@ PTL_FORTRAN :=
 OBJ_FILES_F := 
 
 ifndef PTLF
-PTLF := 0
+PTLF := 1
 endif
 
 ifeq (${PTLF},1)


### PR DESCRIPTION
The object file of PTLf is needed when linking with a Fortran program.
Also, I had to add `-lstdc++` flag as I received an error with recognizing the C++ standard library.